### PR TITLE
Use subset of site names (matching names in the product dropdown)

### DIFF
--- a/0-merge-search.py
+++ b/0-merge-search.py
@@ -18,7 +18,7 @@ from pathlib import Path
 def fetch_url_data():
     base_url = "https://docs.posit.co"
     data = yaml.safe_load(open("./merge_data.yml"))
-    name_url = {entry["name"]: f"{base_url}/{entry['path']}" for entry in data}
+    name_url = [(entry["name"], f"{base_url}/{entry['path']}") for entry in data]
     return name_url
 
 
@@ -57,7 +57,7 @@ def shorten_text(text: str, max_length: int) -> str:
 merged_search_items = []
 
 all_urls = fetch_url_data()
-for name, url in all_urls.items():
+for name, url in all_urls:
     url = url.removesuffix("/")
     r = requests.get(f"{url}/search.json")
     r.raise_for_status()

--- a/app-shiny/app.py
+++ b/app-shiny/app.py
@@ -180,11 +180,6 @@ with ui.layout_sidebar():
         ui.input_checkbox_group("guide_name", label="Product Guide", choices=[])
 
     @render.text
-    def help_why_is_this_happening():
-        return INDEX_NAME
-
-
-    @render.text
     async def row_count():
         res = await filtered_results()
         return f"Results: {len(res)}"

--- a/app-shiny/app.py
+++ b/app-shiny/app.py
@@ -16,7 +16,11 @@ sys.path.append(str(Path(__file__).parent))
 
 from _utils import query
 
+# TODO: currently we pull the names directly from the repo
+# but may want to pull from the index directly.
+# (see fetch_all_results() function below)
 ALL_PRODUCTS = [entry["name"] for entry in yaml.safe_load(open("./merge_data.yml"))]
+
 INDEX_NAME = os.environ.get("ALGOLIA_INDEX", "shiny-prototype-dev")
 
 client = SearchClient("AK1GB1OWGW", "4ac92cf786d83c1a9bef1d2513c77969")
@@ -78,6 +82,17 @@ async def query_df() -> pl.DataFrame:
     # I don't know what Posit Connect Cloud logs from...
     warnings.warn(f"Querying index: {INDEX_NAME}")
     return await query(client, INDEX_NAME, input.text())
+
+# @reactive.calc
+# async def fetch_all_results():
+#     all_results = []
+#     _ = await client.browse_objects(
+#         INDEX_NAME, aggregator=lambda br: all_results.extend(br.hits)
+#     )
+# 
+#     return set([entry["indexName"] for entry in all_results])
+
+
 
 
 @reactive.effect
@@ -159,7 +174,7 @@ async def filtered_results() -> pl.DataFrame:
 
 
 with ui.layout_sidebar():
-    with ui.sidebar(id="left"):
+    with ui.sidebar(id="left", width=275):
         ui.input_text("text", label="Search", value="SSL workbench")
         ui.input_checkbox_group("product_name", label="Product", choices=[])
         ui.input_checkbox_group("guide_name", label="Product Guide", choices=[])

--- a/merge_data.yml
+++ b/merge_data.yml
@@ -14,7 +14,7 @@
 #- name: workbench-user
 #  path: "ide/server-pro/user"
 #  github_url: https://github.com/rstudio/rstudio-pro/tree/main/docs/user/
-- name: Workbench (Licenses)
+- name: Workbench
   path: "ide/licenses"
   github_url: https://github.com/rstudio/rstudio-pro/tree/main/docs/licenses
 
@@ -28,19 +28,20 @@
   path: "rspm"
   github_url: https://github.com/rstudio/package-manager/tree/main/docs/main
 
+# partnerships
+- name: Partnerships
+  path: "partnerships"
+  github_url: https://github.com/rstudio/partnership-docs
+
+
 # RStudio IDE & Desktop ----------
-- name: RStudio (IDE)
+- name: RStudio IDE
   path: "ide/user"
   github_url: https://github.com/rstudio/rstudio/tree/main/docs/user/rstudio
 
 - name: RStudio Desktop Pro
   path: "ide/desktop-pro"
   github_url: https://github.com/rstudio/rstudio-pro/tree/main/docs/desktop
-
-# RStudio IDE & Workbench News
-- name: Workbench & RStudio IDE News
-  path: "ide/news"
-  github_url: https://github.com/rstudio/rstudio-pro/tree/main/docs/news
 
 # Cloud and shinyapps.io ---------
 - name: Posit Cloud
@@ -51,24 +52,21 @@
 #  path: "shinyapps.io"
 #  github_url: https://github.com/rstudio/shinyapps-users-guide
 
-# Partnerships ---------
-- name: Partnerships
-  path: "partnerships"
-  github_url: https://github.com/rstudio/partnership-docs
-
 # not on product dropdown ------------------
-- name: helm 
+- name: Other
   path: "helm"
   github_url: https://github.com/rstudio/helm
-- name: chronicle
-  path: "chronicle"
-  github_url: https://github.com/rstudio/chronicle
-- name: Posit Connect Cloud
-  path: "connect-cloud"
-  github_url: https://github.com/posit-hosted/vivid-docs
-- name: Shiny Server
-  path: "shiny-server"
-  github_url: "https://github.com/rstudio/shiny-server-pro/tree/master/doc"
-- name: Chronicle
+- name: Other
   path: "chronicle"
   github_url: "https://github.com/rstudio/chronicle/tree/main/docs"
+- name: Other #Posit Connect Cloud
+  path: "connect-cloud"
+  github_url: https://github.com/posit-hosted/vivid-docs
+- name: Other # Shiny Server
+  path: "shiny-server"
+  github_url: "https://github.com/rstudio/shiny-server-pro/tree/master/doc"
+
+# RStudio IDE & Workbench News
+- name: Other
+  path: "ide/news"
+  github_url: https://github.com/rstudio/rstudio-pro/tree/main/docs/news


### PR DESCRIPTION
This PR changes many of the product names to other, to cut down on the number of product filters shown. We can totally change this to whatever it useful. But I want to make sure to merge, mostly so I don't lose track of the fixes needed to make this happen!